### PR TITLE
Automatically capture API Gateway request Ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ By default, the following event data is tracked for each log statement.
 | Property                  | Value                                      | Info                                                                     |
 | ------------------------- | ------------------------------------------ | ------------------------------------------------------------------------ |
 | awsRequestId              | context.awsRequestId                       | The unique request id for this request                                   |
+| apiRequestId              | context.requestContext.requestId           | The API Gateway RequestId                                                |
 | x-correlation-id          | event.headers['x-correlation-id']          | The upstream request id for tracing                                      |
 | x-correlation-trace-debug | event.headers['x-correlation-debug']       | The upstream service wants debug logs enabled for this request           |
 | x-correlation-trace-id    | process.env._X_AMZN_TRACE_ID_              | The AWS Xray tracking id                                                 |

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,12 @@ export default (extendedPinoOptions?: ExtendedPinoOptions): PinoLambdaLogger => 
       awsRequestId: context.awsRequestId,
     };
 
+    // capture api gateway request ID
+    const apiRequestId = event.requestContext?.requestId;
+    if (apiRequestId) {
+      ctx.apiRequestId = apiRequestId;
+    }
+
     // capture any correlation headers sent from upstream callers
     if (event.headers) {
       Object.keys(event.headers).forEach((header) => {

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -38,6 +38,15 @@ tap.test('should log an error message with requestId', (t) => {
   t.end();
 });
 
+tap.test('should log an error message with apiRequestId', (t) => {
+  const [log, output] = createLogger();
+
+  log.withRequest({ requestContext: { requestId: '59996' } }, { awsRequestId: '12345' });
+  log.error('Message with apiRequestId');
+  t.matchSnapshot(output.buffer);
+  t.end();
+});
+
 /**
  * Creates a test logger and output buffer for assertions
  * Returns the logger and the buffer

--- a/tap-snapshots/src-tests-index.spec.ts-TAP.test.js
+++ b/tap-snapshots/src-tests-index.spec.ts-TAP.test.js
@@ -9,6 +9,10 @@ exports[`src/tests/index.spec.ts TAP should log a simple info message > must mat
 2016-12-01T06:00:00.000Z	undefined	INFO	Simple message	{"level":30,"time":1480572000000,"msg":"Simple message"}
 `
 
+exports[`src/tests/index.spec.ts TAP should log an error message with apiRequestId > must match snapshot 1`] = `
+2016-12-01T06:00:00.000Z	12345	ERROR	Message with apiRequestId	{"level":50,"time":1480572000000,"awsRequestId":"12345","apiRequestId":"59996","x-correlation-id":"12345","msg":"Message with apiRequestId"}
+`
+
 exports[`src/tests/index.spec.ts TAP should log an error message with requestId > must match snapshot 1`] = `
 2016-12-01T06:00:00.000Z	12345	ERROR	Message with request ID	{"level":50,"time":1480572000000,"awsRequestId":"12345","x-correlation-id":"12345","msg":"Message with request ID"}
 `


### PR DESCRIPTION
Automatically capture the API Gateway request ID by checking the event data.

Reference: https://docs.aws.amazon.com/lambda/latest/dg/services-apigateway.html