### PR TITLE
Align header definition with @types/aws-lambda

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ interface LambdaContext {
 
 interface LamdbaEvent {
   headers?: {
-    [key: string]: string;
+    [key: string]: string | undefined;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18017094/110295122-daaf8700-8044-11eb-9891-9fb7a321b596.png)

When using pino-lambda with @types/aws-lambda you get the following error. Fix is to align the LambdaEvent interface with @types/aws-lambda header definition. #7 