### PR TITLE
Should call function instead of existing checking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export type PinoLambdaLogger = Logger & {
  * that provides convinience methods for use with AWS Lambda
  */
 export default (extendedPinoOptions?: ExtendedPinoOptions): PinoLambdaLogger => {
-  if (!isLamdbaExecution) {
+  if (!isLamdbaExecution()) {
     return (pino(extendedPinoOptions) as unknown) as PinoLambdaLogger;
   }
 


### PR DESCRIPTION
### Situation
* I tried to create logger in Jest unit test. However, it ran pass the if check for lambda execution environment variable. So the check doesn't work. A double check show that it's a function and in order to check, we need to invoke function instead of existing checking.