### PR TITLE
feat!: ignore lambda environments

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Check Commits
-        uses: amannn/action-semantic-pull-request@v3.1.0
+        uses: amannn/action-semantic-pull-request@v3.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ const CORRELATION_ID = `${CORRELATION_HEADER}id`;
 const CORRELATION_TRACE_ID = `${CORRELATION_HEADER}trace-id`;
 const CORRELATION_DEBUG = `${CORRELATION_HEADER}debug`;
 
-const isLamdbaExecution = (): boolean => !!process.env.AWS_EXECUTION_ENV;
 const formatLevel = (level: string | number, levels: LevelMapping): string => {
   if (typeof level === 'string') {
     return level.toLocaleUpperCase();
@@ -84,10 +83,6 @@ export type PinoLambdaLogger = Logger & {
  * that provides convinience methods for use with AWS Lambda
  */
 export default (extendedPinoOptions?: ExtendedPinoOptions): PinoLambdaLogger => {
-  if (!isLamdbaExecution()) {
-    return (pino(extendedPinoOptions) as unknown) as PinoLambdaLogger;
-  }
-
   const options = extendedPinoOptions ?? {};
   const storageProvider = extendedPinoOptions?.storageProvider || GlobalContextStorageProvider;
 

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -2,7 +2,6 @@ import tap from 'tap';
 import sinon from 'sinon';
 import pino, { PinoLambdaLogger, ExtendedPinoOptions } from '../index';
 
-process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs14';
 sinon.useFakeTimers(Date.UTC(2016, 11, 1, 6, 0, 0, 0));
 
 tap.test('should log a simple info message', (t) => {
@@ -97,7 +96,6 @@ tap.test('should capture xray trace IDs', (t) => {
   process.env._X_AMZN_TRACE_ID = undefined;
   t.end();
 });
-
 
 /**
  * Creates a test logger and output buffer for assertions


### PR DESCRIPTION
When running this package under test, it required you to set the AWS_EXECUTION_ENV variable.

Since we now protect against undefined or null values, we no longer need to check the execution environment. Tests can now be run without any special setup.

Fixes #9 