### PR TITLE
feat: add noPreamble option to disable the non json cloudwatch preamble

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export interface ExtendedPinoOptions extends LoggerOptions {
   ) => { [key: string]: string | undefined };
   storageProvider?: ContextStorageProvider;
   streamWriter?: (str: string | Uint8Array) => boolean;
+  noPreamble?: boolean
 }
 
 interface LambdaContext {
@@ -54,7 +55,7 @@ const formatLevel = (level: string | number, levels: LevelMapping): string => {
 const pinolambda = ({ levels, options }: PinoLambdaExtensionOptions): DestinationStream => ({
   write(buffer: string) {
     let output = buffer;
-    if (!options.prettyPrint) {
+    if (!options.prettyPrint && !options.noPreamble) {
       /**
        * Writes to stdout using the same method that AWS lambda uses
        * under the hood for console.log

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -124,6 +124,17 @@ tap.test('should allow removing default request data', (t) => {
   t.end();
 });
 
+tap.test('should allow removing cloudwatch preamble data', (t) => {
+  const [log, output] = createLogger({
+    noPreamble: true
+  });
+
+  log.withRequest({}, { awsRequestId: '431234' });
+  log.info('Message with trace ID');
+  t.matchSnapshot(output.buffer);
+  t.end();
+});
+
 /**
  * Creates a test logger and output buffer for assertions
  * Returns the logger and the buffer

--- a/tap-snapshots/src-tests-index.spec.ts-TAP.test.js
+++ b/tap-snapshots/src-tests-index.spec.ts-TAP.test.js
@@ -9,6 +9,10 @@ exports[`src/tests/index.spec.ts TAP should add tags with a child logger > must 
 2016-12-01T06:00:00.000Z	9048989	INFO	Message with userId	{"level":30,"time":1480572000000,"userId":12,"awsRequestId":"9048989","x-correlation-id":"9048989","msg":"Message with userId"}
 `
 
+exports[`src/tests/index.spec.ts TAP should allow removing cloudwatch preamble data > must match snapshot 1`] = `
+{"level":30,"time":1480572000000,"awsRequestId":"431234","x-correlation-trace-id":"undefined","x-correlation-id":"431234","msg":"Message with trace ID"}
+`
+
 exports[`src/tests/index.spec.ts TAP should allow removing default request data > must match snapshot 1`] = `
 2016-12-01T06:00:00.000Z	431234	INFO	Message with trace ID	{"level":30,"time":1480572000000,"awsRequestId":"431234","x-correlation-trace-id":"undefined","msg":"Message with trace ID"}
 `


### PR DESCRIPTION
closes #18

Happy to rename the option or change logic around. I went with `noPreamble` instead of `preamble` so we wouldn't have to have default value of true in the options.