### PR TITLE
feat: allow customizing log formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ class BananaLogFormatter implements ILogFormatter {
 }
 
 const logger = pino({
-  formatter: new PinoLogFormatter(),
+  formatter: new BananaLogFormatter(),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ pino-lambda
 
 A lightweight drop-in decorator for [pino](https://github.com/pinojs/pino) that takes advantage of the unique environment in AWS Lambda functions.
 
-This wrapper reformats the default pino output so it matches the existing Cloudwatch format. The default pino configuration [loses some of the built in support for request ID tracing](https://github.com/pinojs/pino/issues/648) that lambda has built into Cloudwatch insights.
+By default, this wrapper reformats the log output so it matches the existing Cloudwatch format. The default pino configuration [loses some of the built in support for request ID tracing](https://github.com/pinojs/pino/issues/648) that lambda has built into Cloudwatch insights. This can be disabled or customized as needed.
 
 It also tracks the request id, correlation ids, and xray tracing from upstream services, and can be set to debug mode by upstream services on a per-request basis.
 
@@ -145,6 +145,63 @@ Output
 
 ```
 2018-12-20T17:05:25.330Z    6fccb00e-0479-11e9-af91-d7ab5c8fe19e    INFO  A log message
+{
+   "awsRequestId": "6fccb00e-0479-11e9-af91-d7ab5c8fe19e",
+   "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",
+   "level": 30,
+   "host": "www.host.com",
+   "brand": "famicom",
+   "message": "Some A log message",
+   "data": "Some data"
+}
+```
+
+## Customize output format
+
+If you want the request tracing features, but don't need the Cloudwatch format, you can use the default pino formatter, or supply your own formatter.
+
+```ts
+// default Pino formatter for logs
+import pino, { PinoLogFormatter } from 'pino-lambda';
+const logger = pino({
+  formatter: new PinoLogFormatter(),
+});
+```
+
+Output
+
+```
+{
+   "awsRequestId": "6fccb00e-0479-11e9-af91-d7ab5c8fe19e",
+   "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",
+   "level": 30,
+   "host": "www.host.com",
+   "brand": "famicom",
+   "message": "Some A log message",
+   "data": "Some data"
+}
+```
+
+The formatter function can be replaced with any custom implementation you require by using the supplied interface.
+
+```ts
+import pino, { ExtendedPinoLambdaOptions, ILogFormatter } from 'pino-lambda';
+
+class BananaLogFormatter implements ILogFormatter {
+  format(buffer: string, options: ExtendedPinoLambdaOptions) {
+    return `[BANANA] ${buffer}`;
+  }
+}
+
+const logger = pino({
+  formatter: new PinoLogFormatter(),
+});
+```
+
+Output
+
+```
+[BANANA]
 {
    "awsRequestId": "6fccb00e-0479-11e9-af91-d7ab5c8fe19e",
    "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ other Cloudwatch aware tools such as Datadog and Splunk.
    "x-correlation-id": "238da608-0542-11e9-8eb2-f2801f1b9fd1",
    "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",
    "level": 30,
-   "message": "Some A log message",
+   "message": "A log message",
    "data": "Some data"
 }
 ```
@@ -89,7 +89,7 @@ Cloudwatch Output
    "x-correlation-id": "238da608-0542-11e9-8eb2-f2801f1b9fd1",
    "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",
    "level": 30,
-   "message": "Some A log message",
+   "message": "A log message",
    "data": "Some data"
 }
 ```
@@ -151,7 +151,7 @@ Output
    "level": 30,
    "host": "www.host.com",
    "brand": "famicom",
-   "message": "Some A log message",
+   "message": "A log message",
    "data": "Some data"
 }
 ```
@@ -177,7 +177,7 @@ Output
    "level": 30,
    "host": "www.host.com",
    "brand": "famicom",
-   "message": "Some A log message",
+   "message": "A log message",
    "data": "Some data"
 }
 ```
@@ -208,7 +208,7 @@ Output
    "level": 30,
    "host": "www.host.com",
    "brand": "famicom",
-   "message": "Some A log message",
+   "message": "A log message",
    "data": "Some data"
 }
 ```

--- a/src/formatters/cloudwatch.ts
+++ b/src/formatters/cloudwatch.ts
@@ -1,0 +1,35 @@
+import pino from 'pino';
+import { GlobalContextStorageProvider } from '../context';
+import { ILogFormatter, ExtendedPinoOptions } from '../types';
+
+const formatLevel = (level: string | number): string => {
+  if (typeof level === 'string') {
+    return level.toLocaleUpperCase();
+  } else if (typeof level === 'number') {
+    return pino.levels.labels[level]?.toLocaleUpperCase();
+  }
+  return level;
+};
+
+/**
+ * Formats the log in native cloudwatch format.
+ * Default format for pino-lambda
+ */
+export class CloudwatchLogFormatter implements ILogFormatter {
+  format(buffer: string, options: ExtendedPinoOptions): string {
+    /**
+       * Writes to stdout using the same method that AWS lambda uses
+       * under the hood for console.log
+       * This preserves the default log format of cloudwatch
+       */
+      let output = buffer;
+      const { level, msg } = JSON.parse(buffer);
+      const storageProvider = options.storageProvider || GlobalContextStorageProvider;
+      const { awsRequestId } = storageProvider.getContext() || {};
+      const time = new Date().toISOString();
+      const levelTag = formatLevel(level);
+
+      output = `${time}${awsRequestId ? `\t${awsRequestId}` : ''}\t${levelTag}\t${msg}\t${buffer}`;
+      return output;
+  }
+}

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -1,0 +1,2 @@
+export * from './cloudwatch';
+export * from './pino';

--- a/src/formatters/pino.ts
+++ b/src/formatters/pino.ts
@@ -1,0 +1,10 @@
+import { ILogFormatter } from '../types';
+
+/**
+ * Formats the log in native pino format
+ */
+export class PinoLogFormatter implements ILogFormatter {
+  format(buffer: string): string {
+    return buffer;
+  }
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,5 @@
 import { ContextMap } from './context';
-import { LamdbaEvent, LambdaContext, PinoLambdaLogger, ExtendedPinoOptions } from './types';
+import { LambdaEvent, LambdaContext, PinoLambdaLogger, ExtendedPinoOptions } from './types';
 
 const AMAZON_TRACE_ID = '_X_AMZN_TRACE_ID';
 const CORRELATION_HEADER = 'x-correlation-';
@@ -8,7 +8,7 @@ const CORRELATION_TRACE_ID = `${CORRELATION_HEADER}trace-id`;
 const CORRELATION_DEBUG = `${CORRELATION_HEADER}debug`;
 
 export const withRequest = (logger: PinoLambdaLogger, options: ExtendedPinoOptions) => (
-  event: LamdbaEvent,
+  event: LambdaEvent,
   context: LambdaContext,
 ): void => {
   // keep a reference to the original logger level

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,68 @@
+import { ContextMap } from './context';
+import { LamdbaEvent, LambdaContext, PinoLambdaLogger, ExtendedPinoOptions } from './types';
+
+const AMAZON_TRACE_ID = '_X_AMZN_TRACE_ID';
+const CORRELATION_HEADER = 'x-correlation-';
+const CORRELATION_ID = `${CORRELATION_HEADER}id`;
+const CORRELATION_TRACE_ID = `${CORRELATION_HEADER}trace-id`;
+const CORRELATION_DEBUG = `${CORRELATION_HEADER}debug`;
+
+export const withRequest = (logger: PinoLambdaLogger, options: ExtendedPinoOptions) => (
+  event: LamdbaEvent,
+  context: LambdaContext,
+): void => {
+  // keep a reference to the original logger level
+  const configuredLevel = logger.level;
+
+  const ctx: ContextMap = {
+    awsRequestId: context.awsRequestId,
+  };
+
+  // capture api gateway request ID
+  const apiRequestId = event.requestContext?.requestId;
+  if (apiRequestId) {
+    ctx.apiRequestId = apiRequestId;
+  }
+
+  // capture any correlation headers sent from upstream callers
+  if (event.headers) {
+    Object.keys(event.headers).forEach((header) => {
+      if (header.toLowerCase().startsWith(CORRELATION_HEADER)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        ctx[header] = event.headers![header] as string;
+      }
+    });
+  }
+
+  // capture the xray trace id if its enabled
+  if (process.env[AMAZON_TRACE_ID]) {
+    ctx[CORRELATION_TRACE_ID] = process.env[AMAZON_TRACE_ID] as string;
+  }
+
+  // set the correlation id if not already set by upstream callers
+  if (!ctx[CORRELATION_ID]) {
+    ctx[CORRELATION_ID] = context.awsRequestId;
+  }
+
+  // if an upstream service requests DEBUG mode,
+  // dynamically modify the logging level
+  if (ctx[CORRELATION_DEBUG] === 'true') {
+    logger.level = 'debug';
+  } else {
+    logger.level = configuredLevel;
+  }
+
+  // handle custom request level mixins
+  if (options.requestMixin) {
+    const result = options.requestMixin(event, context);
+    for (const key in result) {
+      // Cast this to string for typescript
+      // when the JSON serializer runs, by default it omits undefined properties
+      ctx[key] = result[key] as string;
+    }
+  }
+
+  if (options.storageProvider) {
+    options.storageProvider.setContext(ctx);
+  }
+};

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,0 +1,29 @@
+import { DestinationStream } from "pino";
+import { CloudwatchLogFormatter } from "./formatters";
+import { ExtendedPinoOptions } from "./types";
+
+/**
+ * Custom destination stream for Pino
+ * @param options Pino options
+ * @param storageProvider Global storage provider for request values
+ */
+export const createStream = (options: ExtendedPinoOptions): DestinationStream => ({
+  write(buffer: string) {
+    let output = buffer;
+    if (!options.prettyPrint) {
+      const formatter = options?.formatter || new CloudwatchLogFormatter();
+      output = formatter.format(buffer, options);
+      
+      // replace characters for proper formatting
+      output = output.replace(/\n/, '\r');
+
+      // final entry must end with carriage return
+      output += '\n';
+    }
+
+    if (options.streamWriter) {
+      return options.streamWriter(output);
+    }
+    return process.stdout.write(output);
+  },
+});

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -1,6 +1,8 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import pino, { PinoLambdaLogger, ExtendedPinoOptions } from '../index';
+import pino, { PinoLambdaLogger } from '../index';
+import { ExtendedPinoOptions } from '../types';
+import { PinoLogFormatter } from '../formatters';
 
 sinon.useFakeTimers(Date.UTC(2016, 11, 1, 6, 0, 0, 0));
 
@@ -120,6 +122,34 @@ tap.test('should allow removing default request data', (t) => {
 
   log.withRequest({}, { awsRequestId: '431234' });
   log.info('Message with trace ID');
+  t.matchSnapshot(output.buffer);
+  t.end();
+});
+
+tap.test('should allow default pino formatter', (t) => {
+  const [log, output] = createLogger({
+    formatter: new PinoLogFormatter(),
+  });
+
+  log.withRequest({}, { awsRequestId: '431234' });
+  log.info('Message with pino formatter');
+  t.matchSnapshot(output.buffer);
+  t.end();
+});
+
+tap.test('should allow custom formatter', (t) => {
+  const bananaFormatter = {
+    format(buffer: string) {
+      return `[BANANA] ${buffer}`;
+    }
+  };
+
+  const [log, output] = createLogger({
+    formatter: bananaFormatter,
+  });
+
+  log.withRequest({}, { awsRequestId: '431234' });
+  log.info('Message with custom formatter');
   t.matchSnapshot(output.buffer);
   t.end();
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,54 @@
+import { LoggerOptions, Logger } from "pino";
+import { ContextStorageProvider } from "./context";
+
+export type PinoLambdaLogger = Logger & {
+  withRequest: (event: LamdbaEvent, context: LambdaContext) => void;
+};
+
+export interface LambdaContext {
+  awsRequestId: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export interface LamdbaEvent {
+  headers?: {
+    [key: string]: string | undefined;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+/**
+ * Interface for implementing log formatters
+ * @interface ILogFormatter
+ */
+export interface ILogFormatter {
+  /**
+   * Formats the log message using the incoming buffer
+   *
+   * @param {string} buffer
+   * @returns {string} The formatted output which must end with a newline
+   * @memberof ILogFormatter
+   */
+  format(buffer: string, options?: ExtendedPinoOptions): string;
+}
+
+/**
+ * Extended options for pino logging
+ *
+ * @export
+ * @interface ExtendedPinoOptions
+ * @extends {LoggerOptions}
+ */
+export interface ExtendedPinoOptions extends LoggerOptions {
+  formatter?: ILogFormatter;
+  requestMixin?: (
+    event: LamdbaEvent,
+    context: LambdaContext,
+  ) => { [key: string]: string | undefined };
+  storageProvider?: ContextStorageProvider;
+  streamWriter?: (str: string | Uint8Array) => boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { LoggerOptions, Logger } from "pino";
 import { ContextStorageProvider } from "./context";
 
 export type PinoLambdaLogger = Logger & {
-  withRequest: (event: LamdbaEvent, context: LambdaContext) => void;
+  withRequest: (event: LambdaEvent, context: LambdaContext) => void;
 };
 
 export interface LambdaContext {
@@ -12,7 +12,7 @@ export interface LambdaContext {
   [key: string]: any;
 }
 
-export interface LamdbaEvent {
+export interface LambdaEvent {
   headers?: {
     [key: string]: string | undefined;
   };
@@ -46,7 +46,7 @@ export interface ILogFormatter {
 export interface ExtendedPinoOptions extends LoggerOptions {
   formatter?: ILogFormatter;
   requestMixin?: (
-    event: LamdbaEvent,
+    event: LambdaEvent,
     context: LambdaContext,
   ) => { [key: string]: string | undefined };
   storageProvider?: ContextStorageProvider;

--- a/tap-snapshots/src-tests-index.spec.ts-TAP.test.js
+++ b/tap-snapshots/src-tests-index.spec.ts-TAP.test.js
@@ -9,6 +9,14 @@ exports[`src/tests/index.spec.ts TAP should add tags with a child logger > must 
 2016-12-01T06:00:00.000Z	9048989	INFO	Message with userId	{"level":30,"time":1480572000000,"userId":12,"awsRequestId":"9048989","x-correlation-id":"9048989","msg":"Message with userId"}
 `
 
+exports[`src/tests/index.spec.ts TAP should allow custom formatter > must match snapshot 1`] = `
+[BANANA] {"level":30,"time":1480572000000,"awsRequestId":"431234","x-correlation-trace-id":"undefined","x-correlation-id":"431234","msg":"Message with custom formatter"}
+`
+
+exports[`src/tests/index.spec.ts TAP should allow default pino formatter > must match snapshot 1`] = `
+{"level":30,"time":1480572000000,"awsRequestId":"431234","x-correlation-trace-id":"undefined","x-correlation-id":"431234","msg":"Message with pino formatter"}
+`
+
 exports[`src/tests/index.spec.ts TAP should allow removing default request data > must match snapshot 1`] = `
 2016-12-01T06:00:00.000Z	431234	INFO	Message with trace ID	{"level":30,"time":1480572000000,"awsRequestId":"431234","x-correlation-trace-id":"undefined","msg":"Message with trace ID"}
 `


### PR DESCRIPTION
Allows customizing the log output so consumers can preserve the native pino format or provide their own in cases where they want  the request tracing features but not the cloudwatch features.

Also refactors the source code to make the files more manageable and fixes a mispelled interface.

*This will be released as a major version*

Closes #16
Closes #18 
Closes #20

## Customize output format

If you want the request tracing features, but don't need the Cloudwatch format, you can use the default pino formatter, or supply your own formatter.

```ts
// default Pino formatter for logs
import pino, { PinoLogFormatter } from 'pino-lambda';
const logger = pino({
  formatter: new PinoLogFormatter(),
});
```

Output

```
{
   "awsRequestId": "6fccb00e-0479-11e9-af91-d7ab5c8fe19e",
   "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",
   "level": 30,
   "host": "www.host.com",
   "brand": "famicom",
   "message": "A log message",
   "data": "Some data"
}
```

The formatter function can be replaced with any custom implementation you require by using the supplied interface.

```ts
import pino, { ExtendedPinoLambdaOptions, ILogFormatter } from 'pino-lambda';

class BananaLogFormatter implements ILogFormatter {
  format(buffer: string, options: ExtendedPinoLambdaOptions) {
    return `[BANANA] ${buffer}`;
  }
}

const logger = pino({
  formatter: new BananaLogFormatter(),
});
```

Output

```
[BANANA]
{
   "awsRequestId": "6fccb00e-0479-11e9-af91-d7ab5c8fe19e",
   "x-correlation-trace-id": "Root=1-5c1bcbd2-9cce3b07143efd5bea1224f2;Parent=07adc05e4e92bf13;Sampled=1",
   "level": 30,
   "host": "www.host.com",
   "brand": "famicom",
   "message": "A log message",
   "data": "Some data"
}
```