### PR TITLE
fix: allow higher pino versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "pino": "^6.0.0"
+    "pino": ">=6.0.0"
   },
   "prettier": {
     "arrowParens": "always",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.1.3"
   },
   "peerDependencies": {
-    "pino": ">=6.0.0"
+    "pino": ">=6.0.0 <8.0.0"
   },
   "prettier": {
     "arrowParens": "always",


### PR DESCRIPTION
Thanks for providing the package pino-lambda.
We use it in combination with pino 7 which seems to work just fine, only npm is making troubles because of the peerDependency pino declared as `^6.0.0`. Would you consider to change it to `>=6.0.0`?

This might resolve #26