### PR TITLE
feat: setting up NPM Provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,15 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      repository-projects: write
+      deployments: write
+      packages: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Pino destination formatter for AWS Lambda",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "repository": "https://github.com/formidablelabs/pino-lambda.git",
+  "repository": "https://github.com/FormidableLabs/pino-lambda.git",
   "files": [
     "/README.md",
     "/dist"
@@ -29,8 +29,8 @@
   ],
   "author": "Charles Brown <charles.brown@formidable.com>",
   "license": "MIT",
-  "homepage": "https://github.com/formidablelabs/pino-lambda#readme",
-  "url": "https://github.com/formidablelabs/pino-lambda/issues",
+  "homepage": "https://github.com/FormidableLabs/pino-lambda#readme",
+  "url": "https://github.com/FormidableLabs/pino-lambda/issues",
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
@@ -59,6 +59,9 @@
   },
   "peerDependencies": {
     "pino": ">=6.0.0"
+  },
+  "publishConfig": {
+    "provenance": true
   },
   "prettier": {
     "arrowParens": "always",


### PR DESCRIPTION
Adding [NPM package provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) for pino-lambda releases