### PR TITLE
feat: support lambda structured logging format

### DIFF
--- a/src/formatters/format.ts
+++ b/src/formatters/format.ts
@@ -1,0 +1,10 @@
+import pino from 'pino';
+
+export const formatLevel = (level: string | number): string => {
+  if (typeof level === 'string') {
+    return level.toLocaleUpperCase();
+  } else if (typeof level === 'number') {
+    return pino.levels.labels[level]?.toLocaleUpperCase();
+  }
+  return level;
+};

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -1,2 +1,3 @@
 export * from './lambda';
 export * from './pino';
+export * from './structured';

--- a/src/formatters/lambda.ts
+++ b/src/formatters/lambda.ts
@@ -1,14 +1,5 @@
-import pino from 'pino';
 import { ILogFormatter, LogData } from '../types';
-
-const formatLevel = (level: string | number): string => {
-  if (typeof level === 'string') {
-    return level.toLocaleUpperCase();
-  } else if (typeof level === 'number') {
-    return pino.levels.labels[level]?.toLocaleUpperCase();
-  }
-  return level;
-};
+import { formatLevel } from './format';
 
 /**
  * Formats the log in native cloudwatch format and

--- a/src/formatters/structured.ts
+++ b/src/formatters/structured.ts
@@ -1,0 +1,18 @@
+import { ILogFormatter, LogData } from '../types';
+import { formatLevel } from './format';
+
+/**
+ * Formats the log in structured JSON format while
+ * including the Lambda context data automatically
+ * @see https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions
+ */
+export class StructuredLogFormatter implements ILogFormatter {
+  format({ awsRequestId, level, ...data }: LogData): string {
+    return JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: formatLevel(level),
+      requestId: awsRequestId,
+      message: data,
+    });
+  }
+}

--- a/src/tests/index.spec.ts
+++ b/src/tests/index.spec.ts
@@ -11,6 +11,7 @@ import {
   LambdaEvent,
   PinoLogFormatter,
   LogData,
+  StructuredLogFormatter,
 } from '../';
 
 import { GlobalContextStorageProvider } from '../context';
@@ -182,6 +183,17 @@ tap.test('should allow removing default request data', (t) => {
 tap.test('should allow default pino formatter', (t) => {
   const { log, output, withRequest } = createLogger(undefined, {
     formatter: new PinoLogFormatter(),
+  });
+
+  withRequest({}, { awsRequestId: '431234' });
+  log.info('Message with pino formatter');
+  t.matchSnapshot(output.buffer);
+  t.end();
+});
+
+tap.test('should allow structured logging format for cloudwatch', (t) => {
+  const { log, output, withRequest } = createLogger(undefined, {
+    formatter: new StructuredLogFormatter(),
   });
 
   withRequest({}, { awsRequestId: '431234' });

--- a/tap-snapshots/src/tests/index.spec.ts.test.cjs
+++ b/tap-snapshots/src/tests/index.spec.ts.test.cjs
@@ -25,6 +25,10 @@ exports[`src/tests/index.spec.ts TAP should allow removing default request data 
 2016-12-01T06:00:00.000Z	431234	INFO	Message with trace ID	{"awsRequestId":"431234","level":30,"time":1480572000000,"msg":"Message with trace ID"}
 `
 
+exports[`src/tests/index.spec.ts TAP should allow structured logging format for cloudwatch > must match snapshot 1`] = `
+{"timestamp":"2016-12-01T06:00:00.000Z","level":"INFO","requestId":"431234","message":{"x-correlation-id":"431234","time":1480572000000,"msg":"Message with pino formatter"}}
+`
+
 exports[`src/tests/index.spec.ts TAP should capture custom request data > must match snapshot 1`] = `
 2016-12-01T06:00:00.000Z	431234	INFO	Message with trace ID	{"awsRequestId":"431234","x-correlation-id":"431234","host":"www.host.com","level":30,"time":1480572000000,"msg":"Message with trace ID"}
 `


### PR DESCRIPTION
Support new AWS Lamdba Advanced JSON formatting for logs. 

Ref: https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/

Closes #50 